### PR TITLE
Missing pvector.dist

### DIFF
--- a/src/pycreative/app.py
+++ b/src/pycreative/app.py
@@ -278,6 +278,13 @@ class Sketch:
                     return ax * bx + ay * by
 
                 @staticmethod
+                def dist(a, b):
+                    """Euclidean distance between two PVectors or 2-length iterables."""
+                    ax, ay = (a.x, a.y) if isinstance(a, PVector) else (float(a[0]), float(a[1]))
+                    bx, by = (b.x, b.y) if isinstance(b, PVector) else (float(b[0]), float(b[1]))
+                    return math.hypot(ax - bx, ay - by)
+
+                @staticmethod
                 def angle_between(a, b):
                     ax, ay = (a.x, a.y) if isinstance(a, PVector) else (float(a[0]), float(a[1]))
                     bx, by = (b.x, b.y) if isinstance(b, PVector) else (float(b[0]), float(b[1]))

--- a/tests/test_pvector_dist.py
+++ b/tests/test_pvector_dist.py
@@ -1,0 +1,21 @@
+def test_pvector_dist_instance_and_classstyle():
+    from pycreative.vector import PVector
+    import math
+
+    v1 = PVector(10, 20)
+    v2 = PVector(60, 80)
+
+    # expected distance between (10,20) and (60,80)
+    expected = math.hypot(50, 60)
+
+    # instance method
+    d1 = v1.dist(v2)
+    assert abs(d1 - expected) < 1e-9
+
+    # class-style/unbound call (PVector.dist(v1, v2)) should work too
+    d2 = PVector.dist(v1, v2)
+    assert abs(d2 - expected) < 1e-9
+
+    # iterable input
+    d3 = v1.dist((60, 80))
+    assert abs(d3 - expected) < 1e-9


### PR DESCRIPTION
## Summary

PVector was missing dist method

## Related issues

N/A

## Checklist

- [x] I added tests covering the new behavior (or gave a clear reason why not).
- [x] I ran `mypy src/` locally and fixed type issues.
- [x] I ran `ruff check src/ tests/` and addressed any findings.
- [x] I ran the test suite locally: `pytest -q`.
- [ ] I updated `docs/` where user-visible behavior changed.
- [ ] If this is a migration from a monolithic module into a package, a compatibility shim that re-exports the public API is included and noted here.

For contribution guidance, see `CONTRIBUTING.md` and `docs/package-style.md`.

Additional notes for reviewers:
- Design decisions:
- Potential follow-ups:
